### PR TITLE
Hot-reload of yaml files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,15 @@ jobs:
         uses: actions/checkout@v3
       - name: docker-up
         run: |
-          docker-compose -f compose.yml -f compose-test.yml --env-file app/.env up -d
+          export TEST_HOST_DATABASE=./app_test.db
+          touch $TEST_HOST_DATABASE
+          HOST_DATABASE=$TEST_HOST_DATABASE \
+            docker-compose \
+            -f compose.yml \
+            -f compose-test.yml \
+            --env-file app/.env \
+            up \
+            -d
           docker ps -a
           # give some time for Flask to spin up.
           sleep 20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
           (
             source app/.env
             source app/.test_env
+            touch $HOST_DATABASE
             docker-compose -f compose.yml -f compose-test.yml --env-file app/.env up -d
           )
           docker ps -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,10 @@ jobs:
           docker ps -a
           # give some time for Flask to spin up.
           sleep 20
-          docker logs $(docker ps -a | grep effort-app | awk '{print $1}') || true
+
+          # and then check the logs to confirm
+          docker logs web-app-test
+          docker logs selenium
 
       - name: test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,11 @@ jobs:
         uses: actions/checkout@v3
       - name: docker-up
         run: |
-          export TEST_HOST_DATABASE=./app_test.db
-          touch $TEST_HOST_DATABASE
-          HOST_DATABASE=$TEST_HOST_DATABASE \
-            docker-compose \
-            -f compose.yml \
-            -f compose-test.yml \
-            --env-file app/.env \
-            up \
-            -d
+          (
+            source app/.env
+            source app/.test_env
+            docker-compose -f compose.yml -f compose-test.yml --env-file app/.env up -d
+          )
           docker ps -a
           # give some time for Flask to spin up.
           sleep 20

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,3 @@ FROM tiangolo/uwsgi-nginx-flask:python3.8
 RUN apt update && apt dist-upgrade -y && apt install curl
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
-COPY ./app /app

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Running the tests requires the `selenium` Python package (can be `pip` or
 `conda`-installed).
 
 ```bash
-docker compose --env-file app/.env -f compose.yml -f compose-test.yml up -d
+export TEST_HOST_DATABASE=./app_testing.db
+touch $TEST_HOST_DATABASE
+HOST_DATABASE=$TEST_HOST_DATABASE docker compose --env-file app/.env -f compose.yml -f compose-test.yml up -d
 python test/test.py
 ```
 

--- a/app/.env
+++ b/app/.env
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# Database will be stored here inside the container
-export DOCKER_DATABASE_DIR="/var/effort/"
+# Database will be stored here on the local host.
+export HOST_DATABASE="./app.db"
 
-# Name of the database
-export DATABASE_NAME="app.db"
-
-# Database will be stored here on the local host. Default is to use the
-# top-level directory of this repo
-export HOST_DATABASE="$(pwd)"
-
+# Database will be stored here inside the container. See the compose.yml file
+# for the bind mount. The app looks for this env var to know where to find it
+# within the docker container.
+export DOCKER_DATABASE="/var/effort/app.db"
 
 # Application lives here on the host and will be bind mounted to DOCKER_APP_DIR
 # in the container.

--- a/app/.env
+++ b/app/.env
@@ -11,6 +11,11 @@ export DATABASE_NAME="app.db"
 export HOST_DATABASE="$(pwd)"
 
 
+# Application lives here on the host and will be bind mounted to DOCKER_APP_DIR
+# in the container.
+export HOST_APP_DIR="./app"
+export DOCKER_APP_DIR="/app"
+
 # LOGIN SETTINGS -------------------------------------------------------------
 # If DISABLE_LDAP=0, then the below LDAP configuration is required. These
 # settings will be highly dependent on the infrastructure and environment in

--- a/app/.test_env
+++ b/app/.test_env
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Override so we don't clobber a production database
+export HOST_DATABASE="./app_test.db"

--- a/app/app/__init__.py
+++ b/app/app/__init__.py
@@ -6,6 +6,7 @@ from flask_bootstrap import Bootstrap
 
 db = SQLAlchemy()
 
+
 def create_app():
     app = Flask(__name__, instance_relative_config=False)
     app.config.from_object(Config)
@@ -16,4 +17,5 @@ def create_app():
 
     with app.app_context():
         from . import routes, models
+
         return app

--- a/app/app/forms.py
+++ b/app/app/forms.py
@@ -12,7 +12,7 @@ USE_LOGIN = not bool(int(os.environ.get("DISABLE_LDAP")))
 if USE_LOGIN:
 
     def IsLoggedInUser(form, field):
-        admin_users = os.environ.get("ADMIN_USERS", "").split(',')
+        admin_users = os.environ.get("ADMIN_USERS", "").split(",")
         if (
             form.personnel.data != current_user.username
             and current_user.username not in admin_users
@@ -23,9 +23,12 @@ if USE_LOGIN:
                 logged in as {current_user.username}!
                 """
             )
+
 else:
+
     def IsLoggedInUser(*args, **kwargs):
         pass
+
 
 def not_dashes(form, field):
     if field.data == "---":
@@ -68,7 +71,6 @@ def day_sums_to_1(form, field):
             or edit the following other entries for this day:
             """
         )
-
 
 
 class EffortForm(FlaskForm):

--- a/app/app/routes.py
+++ b/app/app/routes.py
@@ -21,6 +21,7 @@ from app.forms import EffortForm
 from app.models import Entry
 
 import logging
+
 logging.basicConfig(level=logging.INFO)
 
 # If LDAP is disabled, then create dummy decorators
@@ -45,6 +46,7 @@ else:
     import flask_login
     from flask_ldap3_login import forms as flask_ldap3_login_forms
     from flask_login import current_user
+
     # The login_manager handles Flask login operations, and the ldap_manager
     # handles communication and authentication with the LDAP server.
     login_manager = flask_login.LoginManager(app)
@@ -53,9 +55,7 @@ else:
     # Setting this attribute tells Flask-Login what route to use when redirecting
     # a user to log in.
     login_manager.login_view = "login"
-    login_manager.login_message = (
-        "Please log in to see this page."
-    )
+    login_manager.login_message = "Please log in to see this page."
 
     # Sets up a TLS context with cert, which we need for connecting to the LDAP
     # server.
@@ -73,10 +73,8 @@ else:
         tls_ctx=tls_ctx,
     )
 
-
     # Stores current users
     users = {}
-
 
     class User(flask_login.UserMixin):
         """
@@ -98,7 +96,6 @@ else:
             # Note: Flask-Login requires this to be a string.
             return self.dn
 
-
     # Flask-Login manager requires a callback that takes the string ID of a user
     # and returns the corresponding User object (here, they are stored in the
     # global dict keyed by LDAP DN)
@@ -107,7 +104,6 @@ else:
         if id in users:
             return users[id]
         return None
-
 
     # This is the means by which we communicate between LDAP authentication (via
     # the LDAP3LoginManager) and Flask-Login's LoginManager
@@ -140,7 +136,7 @@ def login():
         ):
             return flask.abort(400)
 
-        return flask.redirect(flask.url_for('index'))
+        return flask.redirect(flask.url_for("index"))
     return flask.render_template("login.html", form=form)
 
 
@@ -148,7 +144,8 @@ def login():
 @app.route("/index")
 @flask_login.login_required
 def index():
-    # Identify the set of personnel to include in the selection dropdown
+    # Identify the set of personnel to include in the selection dropdown,
+    # populated from what's actually in the db (rather than the YAML)
     entries = Entry.query.all()
     personnel_list = ["all"] + list(set([e.personnel for e in entries]))
     bar = plot_over_time()

--- a/app/config.py
+++ b/app/config.py
@@ -10,9 +10,8 @@ class Config(object):
     basedir = os.path.abspath(os.path.dirname(__file__))
 
     SECRET_KEY = os.environ.get("SECRET_KEY") or "unknown"
-    DATABASE_DIR = os.environ.get("DOCKER_DATABASE_DIR", basedir)
-    DATABASE_NAME = os.environ.get("DATABASE_NAME")
-    SQLALCHEMY_DATABASE_URI = f"sqlite:///{DATABASE_DIR}/{DATABASE_NAME}"
+    DATABASE_PATH = os.environ.get("DOCKER_DATABASE")
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{DATABASE_PATH}"
 
     PROJECTS_PATH = os.path.join(basedir, "projects.yaml")
     PERSONNEL_PATH = os.path.join(basedir, "personnel.yaml")

--- a/app/config.py
+++ b/app/config.py
@@ -16,16 +16,9 @@ class Config(object):
     PROJECTS_PATH = os.path.join(basedir, "projects.yaml")
     PERSONNEL_PATH = os.path.join(basedir, "personnel.yaml")
 
-    projects = yaml.load(open(PROJECTS_PATH), Loader=yaml.FullLoader)
-    personnel = yaml.load(open(PERSONNEL_PATH), Loader=yaml.FullLoader)
-
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    YAML = {
-        "personnel": personnel,
-        "projects": projects,
-    }
 
-    # These are loaded into the environment with load_env
+    # These are loaded into the environment with dotenv.load_dotenv() above.
     def get(var):
         return os.environ.get(var, "")
 

--- a/compose-test.yml
+++ b/compose-test.yml
@@ -2,8 +2,6 @@ version: "3.9"
 services:
   web:
     container_name: "web-app-test"
-    environment:
-      - DATABASE_NAME=app_test.db
     ports:
       - "3537:80"
   selenium:

--- a/compose.yml
+++ b/compose.yml
@@ -4,3 +4,4 @@ services:
     build: .
     volumes:
       - ".:${DOCKER_DATABASE_DIR}"
+      - "${HOST_APP_DIR}:${DOCKER_APP_DIR}"

--- a/compose.yml
+++ b/compose.yml
@@ -3,5 +3,5 @@ services:
   web:
     build: .
     volumes:
-      - ".:${DOCKER_DATABASE_DIR}"
       - "${HOST_APP_DIR}:${DOCKER_APP_DIR}"
+      - "${HOST_DATABASE}:${DOCKER_DATABASE}"

--- a/test/test.py
+++ b/test/test.py
@@ -1,7 +1,10 @@
 """
 Usage:
 
-    docker compose --env-file app/.env -f compose.yml -f compose-test.yml up -d
+    (
+      source app/.env; source app/.test_env; 
+      docker compose --env-file app/.env -f compose.yml -f compose-test.yml up -d
+    )
     python test/test.py
 
 Then to stop:


### PR DESCRIPTION
Inspired by #3, this supports changing YAML files on the host and having them automatically be read in whenever the form page is refreshed.

Instead of copying the app dir (and yaml files) to the container, this mounts the entire app dir. And instead of reading the yaml config files into the app.config object in memory at application start, it now reads the yaml files on every rendering of the entry form. Given the expected relatively low usage of this app, repeated reloadings of the yaml files on every rendering is not expected to cause any performance issues.

Mounting the entire app dir rather than copying to the container also has the side effect of allowing the container to write to the migrations dir (flask-migrate, alembic) and have it show up on the host for future restarts.

Getting this all to work nicely required messing around with how env vars are handled within the docker-compose file (which is not well documented). So now we need to source the `.env` and new `.test_env` files within a subshell to get everything to work correctly. The docker-compose file also now mounts the app.db directly via bind mount, but this fails if no app.db exists. So another change is that the the startup instructions (and GH Action testing) now touch the db file first.