### PR TITLE
Fix LDAP users needing to log in multiple times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.8
+FROM tiangolo/uwsgi-nginx-flask:python3.10
 RUN apt update && apt dist-upgrade -y && apt install curl
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/app/app/models.py
+++ b/app/app/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from app import db
+import flask_login
 
 
 class Entry(db.Model):
@@ -18,3 +19,38 @@ class Entry(db.Model):
 
     def to_dict(self):
         return {i: getattr(self, i) for i in self.order}
+
+class User(flask_login.UserMixin, db.Model):
+    """
+    Standard Flask user object, mostly just a container. See
+    https://flask-login.readthedocs.io/en/latest/#your-user-class for what is
+    required on this class, and what is inherited from UserMixin
+    """
+    username = db.Column(db.String(120), primary_key=True)
+    dn = db.Column(db.String(240), index=True)
+    name = db.Column(db.String(120), index=True)
+    data = db.Column(db.String(1000))
+    order = ["username", "dn", "name", "data"]
+
+    def __init__(self, username, dn, data):
+        self.username = username
+        self.dn = dn
+        self.data = build_user_data(data)
+        self.name = data["displayName"]
+
+    def __repr__(self):
+        return self.username
+
+    def get_id(self):
+        # Note: Flask-Login requires this to be a string.
+        return self.username
+    
+    def to_dict(self):
+        return {i: getattr(self, i) for i in self.order}
+
+def build_user_data(data):
+    # For security reasons, save limited information.
+    user_data = {
+        "displayName": data["displayName"]
+    }
+    return str(user_data)


### PR DESCRIPTION
### Problem
Users randomly being presented with the login screen even though they had recently logged in. Switching pages seemed to bring back their session.

### Analysis
There are multiple processes serving requests and so the user's information is only tracked on whatever process handled their log in. We're relying on the LDAP to do the authentication part, and then relying on flask-login manager to tell us what user ID has a current valid session. But, flask-login requires the User object be passed back to it and that object was not shared between processes.

### Solution
Save the user's information to the SQLite DB.

The database just stores the user object in a way that we can retrieve it by user ID to pass it back to flask-login.
Also added a check to only log in users in the personnel file or admin environment variable.

